### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You'll find below a few guidelines to follow when contributing to a Github repos
 
 Workleap doesn't have any specific requirements regarding which account you use to contribute to any of the organization repository. You can use your personal account or create a new account related to Workleap.
 
-However, before contributing, you must associate your Github account to [Workleap Github organization](https://github.com/gsoft-inc). To do so, **open a ticket with infra** and ask to be added to the `gsoft-inc` organization on Github.
+However, before contributing, you must associate your Github account to [Workleap Github organization](https://github.com/workleap). To do so, **open a ticket with infra** and ask to be added to the `gsoft-inc` organization on Github.
 
 ## Repository name
 
@@ -74,4 +74,4 @@ Ex.
 
 ## License
 
-Every open source project developed by Workleap must be under the Apache 2.0 license and link to the following license: https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE
+Every open source project developed by Workleap must be under the Apache 2.0 license and link to the following license: https://github.com/workleap/workleap-license/blob/master/LICENSE


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479